### PR TITLE
Fix Supabase Database type so the build compiles (repairs Netlify deploy)

### DIFF
--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -17,6 +17,7 @@ export interface Database {
         };
         Insert: Omit<Database['public']['Tables']['documents']['Row'], 'id' | 'created_at' | 'updated_at'>;
         Update: Partial<Database['public']['Tables']['documents']['Insert']>;
+        Relationships: [];
       };
       inspections: {
         Row: {
@@ -35,6 +36,7 @@ export interface Database {
         };
         Insert: Omit<Database['public']['Tables']['inspections']['Row'], 'id' | 'created_at' | 'updated_at'>;
         Update: Partial<Database['public']['Tables']['inspections']['Insert']>;
+        Relationships: [];
       };
       deficiencies: {
         Row: {
@@ -52,6 +54,7 @@ export interface Database {
         };
         Insert: Omit<Database['public']['Tables']['deficiencies']['Row'], 'id' | 'created_at' | 'updated_at'>;
         Update: Partial<Database['public']['Tables']['deficiencies']['Insert']>;
+        Relationships: [];
       };
       photos: {
         Row: {
@@ -70,6 +73,7 @@ export interface Database {
         };
         Insert: Omit<Database['public']['Tables']['photos']['Row'], 'id' | 'created_at' | 'updated_at'>;
         Update: Partial<Database['public']['Tables']['photos']['Insert']>;
+        Relationships: [];
       };
       notifications: {
         Row: {
@@ -85,6 +89,7 @@ export interface Database {
         };
         Insert: Omit<Database['public']['Tables']['notifications']['Row'], 'id' | 'created_at'>;
         Update: Partial<Database['public']['Tables']['notifications']['Insert']>;
+        Relationships: [];
       };
       comments: {
         Row: {
@@ -98,6 +103,7 @@ export interface Database {
         };
         Insert: Omit<Database['public']['Tables']['comments']['Row'], 'id' | 'created_at' | 'updated_at'>;
         Update: Partial<Database['public']['Tables']['comments']['Insert']>;
+        Relationships: [];
       };
       activities: {
         Row: {
@@ -111,7 +117,12 @@ export interface Database {
         };
         Insert: Omit<Database['public']['Tables']['activities']['Row'], 'id' | 'created_at'>;
         Update: Partial<Database['public']['Tables']['activities']['Insert']>;
+        Relationships: [];
       };
     };
+    Views: Record<string, never>;
+    Functions: Record<string, never>;
+    Enums: Record<string, never>;
+    CompositeTypes: Record<string, never>;
   };
 }


### PR DESCRIPTION
## Summary

The build (`tsc && vite build`) was failing on `main` — independent of dependencies — which is why the Netlify deploy preview goes red. Every `supabase.from(...)` call inferred as `never`, producing **14 type errors** across `src/lib/api.ts` and `src/pages/Dashboard.tsx` that block `tsc`, and therefore the whole build.

## Root cause

The hand-written `Database` interface in `src/types/database.ts` didn't match the shape `@supabase/supabase-js` v2 requires. Its type helpers use conditional types that collapse every table to `never` when the schema type is missing structural keys. Added the keys the helpers look for:

- `Relationships: []` on each of the 7 tables
- `Views` / `Functions` / `Enums` / `CompositeTypes` on the `public` schema

Types only — no runtime or schema change.

## Verification

- `tsc`: **0 errors** (was 14)
- `npm run build`: completes — 580 modules transformed, `vite build` succeeds

This is a pre-existing break, separate from the dependency refresh in #14 (which was verified not to regress it). Merging this should turn the Netlify deploy green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHRYYxoTfmy5VReVUUcsV2)_